### PR TITLE
Melhoria no teste do alert

### DIFF
--- a/cypress/integration/project.spec.js
+++ b/cypress/integration/project.spec.js
@@ -409,9 +409,17 @@ describe('10 - Faça o quadro de pixels ter seu tamanho definido pelo usuário.'
     let alerted = false;
     cy.on('window:alert', (msg) => alerted = msg);
 
-    cy.get('#generate-board')
-      .click()
-      .then(() => expect(alerted).to.match(/Board inválido!/i));
+    cy.get('#board-size').should(($input) => {
+      const val = $input.val()
+
+      if(val !== ""){
+        cy.get('#board-size').clear()
+      }
+      
+      cy.get('#generate-board')
+        .click()
+        .then(() => expect(alerted).to.match(/Board inválido!/i));
+    })
   });
 
   it('Verifica se ao clicar no botão com um valor preenchido, o tamanho do board muda.', () => {


### PR DESCRIPTION
No requisito 10 é verificado se:
- Se nenhum valor for colocado no input ao clicar no botão, mostre um alert com o texto: "Board inválido!";

Mas não pedimos em nenhum momento que ao iniciar a página o input deve ser vazio.

Aqui eu forço que o input esteja vazio para verificar o teste.

Contexto: uma pessoa estudante, buscando melhorar a experiência, resolveu colocar 5 como valor padrão do input, para não precisar ficar preenchendo sempre. Como consequência, esse requisito não passava, já que ele considerava inicialmente o input já estaria vazio.

